### PR TITLE
Implement Filtration for Club Search

### DIFF
--- a/client/src/components/CardGrid.jsx
+++ b/client/src/components/CardGrid.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import styled from 'styled-components';
 
 import ClubCard from './ClubCard';
@@ -21,7 +21,242 @@ const NoResults = styled.div`
   font-weight: 500;
 `;
 
-const CardGrid = ({ searchQuery = '', userId, clubId }) => {
+// Hard-coded data to mirror MongoDB schema fields for testing
+// Fields mirrored from server/models/clubModel.js: clubName, clubType, major, meetingDays, size
+// Additional frontend-only fields: abbreviation, description, img
+const clubs = [
+  {
+    abbreviation: 'UPE',
+    clubName: 'Upsilon Pi Epsilon',
+    clubType: 'Professional', // not in filter; will still show unless filtered by other fields
+    major: 'Computer Science',
+    meetingDays: 'Wed',
+    size: '120',
+    description: 'Upsilon Pi Epsilon - Computer Science Honors Society',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/upe.png',
+  },
+  {
+    abbreviation: 'BSG',
+    clubName: 'Bruin Spacecraft Group',
+    clubType: 'Project-based',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Mon, Thurs',
+    size: '80',
+    description: 'Bruin Space - Aerospace engineering and space exploration',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/bsg.png',
+  },
+  {
+    abbreviation: 'ASME',
+    clubName: 'American Society of Mechanical Engineers',
+    clubType: 'Professional',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Tues',
+    size: '150',
+    description: 'American Society of Mechanical Engineers at UCLA',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/asme.png',
+  },
+  {
+    abbreviation: 'AIAA',
+    clubName: 'American Institute of Aeronautics and Astronautics',
+    clubType: 'Professional',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Wed',
+    size: '140',
+    description: 'American Institute of Aeronautics and Astronautics',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/aiaa.png',
+  },
+  {
+    abbreviation: 'DBF',
+    clubName: 'Design Build Fly',
+    clubType: 'Project-based',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Sat',
+    size: '60',
+    description: 'Design Build Fly - Aerospace design competition team',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/dbf.png',
+  },
+  {
+    abbreviation: 'IEEE',
+    clubName: 'Institute of Electrical and Electronics Engineers',
+    clubType: 'Professional',
+    major: 'Electrical Engineering',
+    meetingDays: 'Fri',
+    size: '200',
+    description: 'Institute of Electrical and Electronics Engineers',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ieee.png',
+  },
+  {
+    abbreviation: 'QWER Hacks',
+    clubName: 'QWER Hacks',
+    clubType: 'Equity, Diversity, & Inclusion',
+    major: 'Computer Science',
+    meetingDays: 'Sun',
+    size: '40',
+    description: 'QWER Hacks - LGBTQ+ hackathon organization',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/qwerhacks.png',
+  },
+  {
+    abbreviation: 'MRS',
+    clubName: 'Materials Research Society',
+    clubType: 'Professional',
+    major: 'Materials',
+    meetingDays: 'Thurs',
+    size: '70',
+    description: 'Materials Research Society - Materials science and engineering',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/mrs.png',
+  },
+  {
+    abbreviation: 'AIChe',
+    clubName: 'American Institute of Chemical Engineers',
+    clubType: 'Professional',
+    major: 'Chemical',
+    meetingDays: 'Wed',
+    size: '110',
+    description: 'American Institute of Chemical Engineers',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/aiche.png',
+  },
+  {
+    abbreviation: 'ITE',
+    clubName: 'Institute of Transportation Engineers',
+    clubType: 'Professional',
+    major: 'Civil/Environmental Engineering',
+    meetingDays: 'Tues',
+    size: '55',
+    description: 'Institute of Transportation Engineers',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ite.png',
+  },
+  {
+    abbreviation: '3D4E',
+    clubName: '3D4E',
+    clubType: 'Project-based',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Mon',
+    size: '45',
+    description: '3D4E - 3D printing and additive manufacturing',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/3d4e.png',
+  },
+  {
+    abbreviation: 'MentorSEAS',
+    clubName: 'MentorSEAS',
+    clubType: 'Education & Outreach',
+    major: 'Engineering',
+    meetingDays: 'Wed',
+    size: '30',
+    description: 'MentorSEAS - Engineering mentorship program',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/mentorseas.png',
+  },
+  {
+    abbreviation: 'UAS@UCLA',
+    clubName: 'UAS at UCLA',
+    clubType: 'Project-based',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Sun',
+    size: '90',
+    description: 'UAS@UCLA - Unmanned Aerial Systems team',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/uas.png',
+  },
+  {
+    abbreviation: 'BMES',
+    clubName: 'Biomedical Engineering Society',
+    clubType: 'Professional',
+    major: 'Bioengineering',
+    meetingDays: 'Thurs',
+    size: '85',
+    description: 'Biomedical Engineering Society',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/bmes.png',
+  },
+  {
+    abbreviation: 'Rocket Project',
+    clubName: 'Rocket Project',
+    clubType: 'Project-based',
+    major: 'Mechanical/Aerospace Engineering',
+    meetingDays: 'Sat',
+    size: '75',
+    description: 'Rocket Project - Rocket design and launch team',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/rocketproject.png',
+  },
+  {
+    abbreviation: 'SWE',
+    clubName: 'Society of Women Engineers',
+    clubType: 'Equity, Diversity, & Inclusion',
+    major: 'Engineering',
+    meetingDays: 'Wed',
+    size: '180',
+    description: 'Society of Women Engineers',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/swe.png',
+  },
+  {
+    abbreviation: 'ACM@UCLA',
+    clubName: 'Association for Computing Machinery',
+    clubType: 'Project-based',
+    major: 'Computer Science',
+    meetingDays: 'Fri',
+    size: '220',
+    description: 'Association for Computing Machinery at UCLA',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/acm.png',
+  },
+  {
+    abbreviation: 'SOLES|SHPE@UCLA',
+    clubName: 'SOLES and SHPE at UCLA',
+    clubType: 'Equity, Diversity, & Inclusion',
+    major: 'Engineering',
+    meetingDays: 'Tues',
+    size: '130',
+    description: 'SOLES and SHPE - Society of Latino Engineers and Scientists',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/soles.png',
+  },
+  {
+    abbreviation: 'EWB',
+    clubName: 'Engineers Without Borders',
+    clubType: 'Education & Outreach',
+    major: 'Civil/Environmental Engineering',
+    meetingDays: 'Mon',
+    size: '65',
+    description: 'Engineers Without Borders - International development projects',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ewb.png',
+  },
+  {
+    abbreviation: 'IEEE-WIE',
+    clubName: 'IEEE Women in Engineering',
+    clubType: 'Equity, Diversity, & Inclusion',
+    major: 'Electrical Engineering',
+    meetingDays: 'Thurs',
+    size: '90',
+    description: 'IEEE Women in Engineering',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ieee-wie.png',
+  },
+  {
+    abbreviation: 'SWUG',
+    clubName: 'Software Undergraduate Group',
+    clubType: 'Project-based',
+    major: 'Computer Science',
+    meetingDays: 'Wed',
+    size: '35',
+    description: 'Software Undergraduate Group',
+    img: 'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/swug.png',
+  },
+];
+
+const normalizeDay = (d) => {
+  const x = d.trim().toLowerCase();
+  if (x.startsWith('tue')) return 'Tues';
+  if (x.startsWith('thu')) return 'Thurs';
+  if (x.startsWith('wed')) return 'Wed';
+  if (x.startsWith('mon')) return 'Mon';
+  if (x.startsWith('fri')) return 'Fri';
+  if (x.startsWith('sat')) return 'Sat';
+  if (x.startsWith('sun')) return 'Sun';
+  return d;
+};
+
+const sizePredicates = {
+  '< 25 Members': (n) => n < 25,
+  '< 50 Members': (n) => n < 50,
+  '< 75 Members': (n) => n < 75,
+  '100+ Members': (n) => n >= 100,
+};
+
+const CardGrid = ({ searchQuery = '', userId, clubId, filters = {} }) => {
   const [openIndex, setOpenIndex] = useState(null);
 
   const handleOpenModal = (index) => {
@@ -32,91 +267,56 @@ const CardGrid = ({ searchQuery = '', userId, clubId }) => {
     setOpenIndex(null);
   };
 
-  const image = [
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/upe.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/bsg.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/asme.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/aiaa.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/dbf.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ieee.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/qwerhacks.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/mrs.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/aiche.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ite.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/3d4e.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/mentorseas.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/uas.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/bmes.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/rocketproject.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/swe.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/acm.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/soles.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ewb.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/ieee-wie.png',
-    'https://www.esuc.ucla.edu/winter-orgs/assets/img/orgs/swug.png',
-  ];
-  const title = [
-    'UPE',
-    'BSG',
-    'ASME',
-    'AIAA',
-    'DBF',
-    'IEEE',
-    'MRS',
-    'QWER Hacks',
-    'AIChe',
-    'ITE',
-    '3D4E',
-    'MentorSEAS',
-    'UAS@UCLA',
-    'BMES',
-    'Rocket Project',
-    'SWE',
-    'ACM@UCLA',
-    'SOLES|SHPE@UCLA',
-    'EWB',
-    'IEEE-WIE',
-    'SWUG',
-  ];
+  const { types = [], majors = [], days = [], sizes = [] } = filters;
 
-  const descriptions = [
-    'Upsilon Pi Epsilon - Computer Science Honors Society',
-    'Bruin Space - Aerospace engineering and space exploration',
-    'American Society of Mechanical Engineers at UCLA',
-    'American Institute of Aeronautics and Astronautics',
-    'Design Build Fly - Aerospace design competition team',
-    'Institute of Electrical and Electronics Engineers',
-    'QWER Hacks - LGBTQ+ hackathon organization',
-    'Materials Research Society - Materials science and engineering',
-    'American Institute of Chemical Engineers',
-    'Institute of Transportation Engineers',
-    '3D4E - 3D printing and additive manufacturing',
-    'MentorSEAS - Engineering mentorship program',
-    'UAS@UCLA - Unmanned Aerial Systems team',
-    'Biomedical Engineering Society',
-    'Rocket Project - Rocket design and launch team',
-    'Society of Women Engineers',
-    'Association for Computing Machinery at UCLA',
-    'SOLES and SHPE - Society of Latino Engineers and Scientists',
-    'Engineers Without Borders - International development projects',
-    'IEEE Women in Engineering',
-    'Software Undergraduate Group',
-  ];
+  const filtered = useMemo(() => {
+    const q = (searchQuery || '').trim().toLowerCase();
 
-  const filteredClubs = Array.from({ length: 21 }).filter((_, index) => {
-    if (!searchQuery.trim()) return true;
-    const query = searchQuery.toLowerCase();
-    const clubName = title[index].toLowerCase();
-    const description = descriptions[index].toLowerCase();
-    return clubName.includes(query) || description.includes(query);
-  });
+    return clubs
+      .map((c, i) => ({ ...c, __index: i }))
+      .filter((c) => {
+        // searches for abbreviation, name, and description
+        const matchesSearch = !q
+          ? true
+          : [c.abbreviation, c.clubName, c.description]
+              .filter(Boolean)
+              .some((t) => t.toLowerCase().includes(q));
 
-  if (filteredClubs.length === 0 && searchQuery.trim()) {
+        if (!matchesSearch) return false;
+
+        // Type filter
+        const matchesType = types.length === 0 ? true : types.includes(c.clubType);
+        if (!matchesType) return false;
+
+        // Major filter
+        const matchesMajor = majors.length === 0 ? true : majors.includes(c.major);
+        if (!matchesMajor) return false;
+
+        // Meeting days filter
+        const clubDays = (c.meetingDays || '')
+          .split(',')
+          .map((d) => normalizeDay(d))
+          .filter(Boolean);
+        const matchesDays = days.length === 0 ? true : days.some((d) => clubDays.includes(d));
+        if (!matchesDays) return false;
+
+        // Size filter
+        const sizeNum = parseInt(String(c.size), 10);
+        const matchesSize = sizes.length === 0
+          ? true
+          : sizes.some((label) => (sizePredicates[label] ? sizePredicates[label](sizeNum) : true));
+        if (!matchesSize) return false;
+
+        return true;
+      });
+  }, [searchQuery, types, majors, days, sizes]);
+
+  if (filtered.length === 0) {
     return (
       <NoResults>
-        <div>No clubs found matching "{searchQuery}"</div>
+        <div>No clubs found{searchQuery?.trim() ? ` matching "${searchQuery}"` : ''}</div>
         <div style={{ fontSize: '0.9rem', marginTop: '8px', color: '#94a3b8' }}>
-          Try searching for different keywords or browse all clubs
+          Try adjusting your filters or search keywords
         </div>
       </NoResults>
     );
@@ -124,29 +324,26 @@ const CardGrid = ({ searchQuery = '', userId, clubId }) => {
 
   return (
     <Grid>
-      {filteredClubs.map((_, index) => {
-        const originalIndex = Array.from({ length: 21 }).findIndex((_, i) => {
-          if (!searchQuery.trim()) return i === index;
-          const query = searchQuery.toLowerCase();
-          const clubName = title[i].toLowerCase();
-          const description = descriptions[i].toLowerCase();
-          return clubName.includes(query) || description.includes(query);
-        });
-        return (
-          <ClubCard
-            img={image[originalIndex]}
-            title={title[originalIndex]}
-            isBoxOpen={openIndex === originalIndex}
-            onOpen={() => handleOpenModal(originalIndex)}
-            onClose={handleCloseModal}
-            key={title[originalIndex]}
-            userId={userId}
-            clubId={clubId}
-          >
-            Card {originalIndex + 1}
-          </ClubCard>
-        );
-      })}
+      {filtered.map((c, idx) => (
+        <ClubCard
+          img={c.img}
+          title={c.abbreviation}
+          fullName={c.clubName}
+          description={c.description}
+          clubType={c.clubType}
+          major={c.major}
+          meetingDays={c.meetingDays}
+          size={c.size}
+          isBoxOpen={openIndex === c.__index}
+          onOpen={() => handleOpenModal(c.__index)}
+          onClose={handleCloseModal}
+          key={c.abbreviation}
+          userId={userId}
+          clubId={clubId}
+        >
+          Card {idx + 1}
+        </ClubCard>
+      ))}
     </Grid>
   );
 };

--- a/client/src/components/ClubCard.jsx
+++ b/client/src/components/ClubCard.jsx
@@ -182,7 +182,21 @@ const BoxClose = styled.button`
   }
 `;
 
-const ClubCard = ({ isBoxOpen, onOpen, onClose, img, title, userId, clubId }) => {
+const ClubCard = ({
+  isBoxOpen,
+  onOpen,
+  onClose,
+  img,
+  title,
+  userId,
+  clubId,
+  fullName,
+  description,
+  clubType,
+  major,
+  meetingDays,
+  size,
+}) => {
   const [isFavorited, setIsFavorited] = useState(false);
 
   const handleToggleFavorite = () => {
@@ -226,6 +240,8 @@ const ClubCard = ({ isBoxOpen, onOpen, onClose, img, title, userId, clubId }) =>
     return fullNames[clubTitle] || clubTitle;
   };
 
+  const displayFullName = fullName || getFullName(title);
+
   return (
     <>
       <CardContainer onClick={onOpen}>
@@ -246,21 +262,41 @@ const ClubCard = ({ isBoxOpen, onOpen, onClose, img, title, userId, clubId }) =>
         </LogoSection>
 
         <FooterSection>
-          <FullName>{getFullName(title)}</FullName>
+          <FullName>{displayFullName}</FullName>
           <Abbreviation>{title}</Abbreviation>
         </FooterSection>
 
         {createPortal(
+          //added details for when the card is clicked
           <Box isOpen={isBoxOpen} onClick={onClose}>
             <Content onClick={(e) => e.stopPropagation()}>
-              <h1 style={{ color: '#0f172a', marginBottom: '16px' }}>{title}</h1>
+              <h1 style={{ color: '#0f172a', marginBottom: '12px', fontSize: '1.25rem' }}>
+                {displayFullName}
+              </h1>
+              <div style={{ color: '#94a3b8', fontSize: '0.85rem', marginBottom: '8px' }}>{title}</div>
               <p style={{ color: '#64748b', lineHeight: '1.6', marginBottom: '16px' }}>
-                {getFullName(title)} - A student organization dedicated to fostering innovation,
-                collaboration, and professional development in engineering at UCLA.
+                {description || `${displayFullName} - A student organization dedicated to fostering innovation, collaboration, and professional development in engineering at UCLA.`}
               </p>
-              <div style={{ color: '#f59e0b', fontWeight: '600', marginBottom: '8px' }}>
-                Meeting Times: TBD
-              </div>
+              {clubType && (
+                <div style={{ color: '#0f172a', fontWeight: 600, marginBottom: '6px' }}>
+                  Type: <span style={{ color: '#334155', fontWeight: 500 }}>{clubType}</span>
+                </div>
+              )}
+              {major && (
+                <div style={{ color: '#0f172a', fontWeight: 600, marginBottom: '6px' }}>
+                  Major: <span style={{ color: '#334155', fontWeight: 500 }}>{major}</span>
+                </div>
+              )}
+              {meetingDays && (
+                <div style={{ color: '#0f172a', fontWeight: 600, marginBottom: '6px' }}>
+                  Meeting Days: <span style={{ color: '#334155', fontWeight: 500 }}>{meetingDays}</span>
+                </div>
+              )}
+              {size && (
+                <div style={{ color: '#0f172a', fontWeight: 600, marginBottom: '12px' }}>
+                  Size: <span style={{ color: '#334155', fontWeight: 500 }}>{size} members</span>
+                </div>
+              )}
               <div style={{ color: '#64748b', fontSize: '0.9rem' }}>
                 Contact: {title.toLowerCase()}@ucla.edu
               </div>

--- a/client/src/pages/home.jsx
+++ b/client/src/pages/home.jsx
@@ -123,12 +123,29 @@ const SearchContainer = styled.div`
 export const Home = () => {
   const [searchQuery, setSearchQuery] = useState('');
 
+  // Filter state
+  const [selectedTypes, setSelectedTypes] = useState([]);
+  const [selectedMajors, setSelectedMajors] = useState([]);
+  const [selectedDays, setSelectedDays] = useState([]);
+  const [selectedSizes, setSelectedSizes] = useState([]);
+
+  const toggleValue = (value, list, setter) => {
+    setter((prev) => (prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]));
+  };
+
   // TEMPORARY WILL CHANGE LATER
   const userId = '6627638285b11e9ed9d11fc9'; // john bruin
   const clubId = '6909d80faf668433ff54eced'; // UPE
 
   const handleSearchChange = (event, newValue) => {
     setSearchQuery(newValue || '');
+  };
+
+  const filters = {
+    types: selectedTypes,
+    majors: selectedMajors,
+    days: selectedDays,
+    sizes: selectedSizes,
   };
 
   return (
@@ -156,10 +173,59 @@ export const Home = () => {
             </AccordionSummary>
             <AccordionDetails>
               <FormControl>
-                <FormControlLabel control={<Checkbox />} label="Project-based" />
-                <FormControlLabel control={<Checkbox />} label="Greek" />
-                <FormControlLabel control={<Checkbox />} label="Education & Outreach" />
-                <FormControlLabel control={<Checkbox />} label="Equity, Diversity, & Inclusion" />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedTypes.includes('Project-based')}
+                      onChange={() => toggleValue('Project-based', selectedTypes, setSelectedTypes)}
+                    />
+                  }
+                  label="Project-based"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedTypes.includes('Greek')}
+                      onChange={() => toggleValue('Greek', selectedTypes, setSelectedTypes)}
+                    />
+                  }
+                  label="Greek"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedTypes.includes('Education & Outreach')}
+                      onChange={() =>
+                        toggleValue('Education & Outreach', selectedTypes, setSelectedTypes)
+                      }
+                    />
+                  }
+                  label="Education & Outreach"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedTypes.includes('Equity, Diversity, & Inclusion')}
+                      onChange={() =>
+                        toggleValue(
+                          'Equity, Diversity, & Inclusion',
+                          selectedTypes,
+                          setSelectedTypes
+                        )
+                      }
+                    />
+                  }
+                  label="Equity, Diversity, & Inclusion"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedTypes.includes('Professional')}
+                      onChange={() => toggleValue('Professional', selectedTypes, setSelectedTypes)}
+                    />
+                  }
+                  label="Professional"
+                />
               </FormControl>
             </AccordionDetails>
           </Accordion>
@@ -173,11 +239,92 @@ export const Home = () => {
             </AccordionSummary>
             <AccordionDetails>
               <FormControl>
-                <FormControlLabel control={<Checkbox />} label="Computer Science" />
-                <FormControlLabel control={<Checkbox />} label="Electrical Engineering" />
-                <FormControlLabel control={<Checkbox />} label="Mechanical/Aerospace Engineering" />
-                <FormControlLabel control={<Checkbox />} label="Civil/Environmental Engineering" />
-                <FormControlLabel control={<Checkbox />} label="Bioengineering" />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Computer Science')}
+                      onChange={() => toggleValue('Computer Science', selectedMajors, setSelectedMajors)}
+                    />
+                  }
+                  label="Computer Science"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Electrical Engineering')}
+                      onChange={() =>
+                        toggleValue('Electrical Engineering', selectedMajors, setSelectedMajors)
+                      }
+                    />
+                  }
+                  label="Electrical Engineering"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Mechanical/Aerospace Engineering')}
+                      onChange={() =>
+                        toggleValue(
+                          'Mechanical/Aerospace Engineering',
+                          selectedMajors,
+                          setSelectedMajors
+                        )
+                      }
+                    />
+                  }
+                  label="Mechanical/Aerospace Engineering"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Civil/Environmental Engineering')}
+                      onChange={() =>
+                        toggleValue(
+                          'Civil/Environmental Engineering',
+                          selectedMajors,
+                          setSelectedMajors
+                        )
+                      }
+                    />
+                  }
+                  label="Civil/Environmental Engineering"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Bioengineering')}
+                      onChange={() => toggleValue('Bioengineering', selectedMajors, setSelectedMajors)}
+                    />
+                  }
+                  label="Bioengineering"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Materials')}
+                      onChange={() => toggleValue('Materials', selectedMajors, setSelectedMajors)}
+                    />
+                  }
+                  label="Materials"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Chemical')}
+                      onChange={() => toggleValue('Chemical', selectedMajors, setSelectedMajors)}
+                    />
+                  }
+                  label="Chemical"
+                />
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedMajors.includes('Engineering')}
+                      onChange={() => toggleValue('Engineering', selectedMajors, setSelectedMajors)}
+                    />
+                  }
+                  label="Engineering"
+                />
               </FormControl>
             </AccordionDetails>
           </Accordion>
@@ -191,13 +338,18 @@ export const Home = () => {
             </AccordionSummary>
             <AccordionDetails>
               <FormControl>
-                <FormControlLabel control={<Checkbox />} label="Sun" />
-                <FormControlLabel control={<Checkbox />} label="Mon" />
-                <FormControlLabel control={<Checkbox />} label="Tues" />
-                <FormControlLabel control={<Checkbox />} label="Wed" />
-                <FormControlLabel control={<Checkbox />} label="Thurs" />
-                <FormControlLabel control={<Checkbox />} label="Fri" />
-                <FormControlLabel control={<Checkbox />} label="Sat" />
+                {['Sun', 'Mon', 'Tues', 'Wed', 'Thurs', 'Fri', 'Sat'].map((d) => (
+                  <FormControlLabel
+                    key={d}
+                    control={
+                      <Checkbox
+                        checked={selectedDays.includes(d)}
+                        onChange={() => toggleValue(d, selectedDays, setSelectedDays)}
+                      />
+                    }
+                    label={d}
+                  />
+                ))}
               </FormControl>
             </AccordionDetails>
           </Accordion>
@@ -211,10 +363,18 @@ export const Home = () => {
             </AccordionSummary>
             <AccordionDetails>
               <FormControl>
-                <FormControlLabel control={<Checkbox />} label="< 25 Members" />
-                <FormControlLabel control={<Checkbox />} label="< 50 Members" />
-                <FormControlLabel control={<Checkbox />} label="< 75 Members" />
-                <FormControlLabel control={<Checkbox />} label="100+ Members" />
+                {['< 25 Members', '< 50 Members', '< 75 Members', '100+ Members'].map((s) => (
+                  <FormControlLabel
+                    key={s}
+                    control={
+                      <Checkbox
+                        checked={selectedSizes.includes(s)}
+                        onChange={() => toggleValue(s, selectedSizes, setSelectedSizes)}
+                      />
+                    }
+                    label={s}
+                  />
+                ))}
               </FormControl>
             </AccordionDetails>
           </Accordion>
@@ -272,7 +432,7 @@ export const Home = () => {
               )}
             />
           </SearchContainer>
-          <CardGrid searchQuery={searchQuery} userId={userId} clubId={clubId} />
+          <CardGrid searchQuery={searchQuery} userId={userId} clubId={clubId} filters={filters} />
         </section>
       </div>
     </div>


### PR DESCRIPTION
**Issue:** #23 
 
**Current solution**

CardGrid.jsx:
- Had chat cook up a dummy clubs array in a Mongo-style format (added meetingDays + size)
- Text search now checks abbreviation, full clubName, and description
- Filtering works for club type, major, meeting days, and size (all ANDed rn)

Home.jsx:
- Expanded the filter options to match all the data (threw in materials/chemical/etc: can delete later if that’s dtm LOL)

ClubCard.jsx:
- Modal now shows Type, Major, Meeting Days, and Size

**Possible bugs/comments**
- Mock data will prob need cleanup once real Mongo docs come in
- Might want to revisit “AND” filtering if it becomes too restrictive